### PR TITLE
Improve endpoint detection logic.

### DIFF
--- a/pkg/controller/repository/repository_controller.go
+++ b/pkg/controller/repository/repository_controller.go
@@ -191,14 +191,8 @@ func makeParams(commit git.Commit, spec pollingv1.RepositorySpec) ([]pipelinev1.
 func makeCommitPoller(repo *pollingv1.Repository, endpoint, authToken string) git.CommitPoller {
 	switch repo.Spec.Type {
 	case pollingv1.GitHub:
-		if endpoint == "https://github.com" {
-			endpoint = ""
-		}
 		return git.NewGitHubPoller(http.DefaultClient, endpoint, authToken)
 	case pollingv1.GitLab:
-		if endpoint == "https://gitlab.com" {
-			endpoint = ""
-		}
 		return git.NewGitLabPoller(http.DefaultClient, endpoint, authToken)
 	}
 	return nil
@@ -209,7 +203,10 @@ func repoFromURL(s string) (string, string, error) {
 	if err != nil {
 		return "", "", fmt.Errorf("failed to parse repo from URL %#v: %s", s, err)
 	}
-
-	endpoint := fmt.Sprintf("%s://%s", parsed.Scheme, parsed.Host)
+	host := parsed.Host
+	if strings.HasSuffix(host, "github.com") {
+		host = "api." + host
+	}
+	endpoint := fmt.Sprintf("%s://%s", parsed.Scheme, host)
 	return strings.TrimPrefix(strings.TrimSuffix(parsed.Path, ".git"), "/"), endpoint, nil
 }

--- a/pkg/controller/repository/repository_controller_test.go
+++ b/pkg/controller/repository/repository_controller_test.go
@@ -261,6 +261,33 @@ func TestReconcileRepositoryClearsLastErrorOnSuccessfulPoll(t *testing.T) {
 	fatalIfError(t, cl.Get(ctx, req.NamespacedName, loaded))
 }
 
+func Test_repoFromURL(t *testing.T) {
+	urlTests := []struct {
+		url          string
+		wantPath     string
+		wantEndpoint string
+	}{
+		{"https://github.com/my-org/my-repo.git", "my-org/my-repo", "https://api.github.com"},
+		{"https://gitlab.com/my-org/my-repo.git", "my-org/my-repo", "https://gitlab.com"},
+		{"https://example.github.com/my-org/my-repo.git", "my-org/my-repo", "https://api.example.github.com"},
+		{"https://example.com/my-org/my-repo.git", "my-org/my-repo", "https://example.com"},
+	}
+
+	for _, tt := range urlTests {
+		path, endpoint, err := repoFromURL(tt.url)
+		if err != nil {
+			t.Errorf("repoFromURL(%q) failed with an error: %s", tt.url, err)
+			continue
+		}
+		if path != tt.wantPath {
+			t.Errorf("repoFromURL(%q) path got %q, want %q", tt.url, path, tt.wantPath)
+		}
+		if endpoint != tt.wantEndpoint {
+			t.Errorf("repoFromURL(%q) endpoint got %q, want %q", tt.url, endpoint, tt.wantEndpoint)
+		}
+	}
+}
+
 func makeRepository(opts ...func(*pollingv1.Repository)) *pollingv1.Repository {
 	r := &pollingv1.Repository{
 		ObjectMeta: metav1.ObjectMeta{

--- a/pkg/git/github.go
+++ b/pkg/git/github.go
@@ -23,11 +23,8 @@ const (
 	chitauriPreview = "application/vnd.github.chitauri-preview+sha"
 )
 
-// NewGitHubPoller creates a new GitHub poller.
+// NewGitHubPoller creates and returns a new GitHub poller.
 func NewGitHubPoller(c *http.Client, endpoint, authToken string) *GitHubPoller {
-	if endpoint == "" {
-		endpoint = "https://api.github.com"
-	}
 	return &GitHubPoller{client: c, endpoint: endpoint, authToken: authToken}
 }
 

--- a/pkg/git/github_test.go
+++ b/pkg/git/github_test.go
@@ -19,13 +19,11 @@ func TestNewGitHubPoller(t *testing.T) {
 		endpoint     string
 		wantEndpoint string
 	}{
-		{"", "https://api.github.com"},
 		{"https://gh.example.com", "https://gh.example.com"},
 	}
 
 	for _, tt := range newTests {
 		c := NewGitHubPoller(http.DefaultClient, tt.endpoint, "testToken")
-
 		if c.endpoint != tt.wantEndpoint {
 			t.Errorf("%#v got %#v, want %#v", tt.endpoint, c.endpoint, tt.wantEndpoint)
 		}


### PR DESCRIPTION
When parsing the RepoURL, if the host ends in github.com then append an "api." to it.

This handles the normal `"https://github.com/my-org/my-repo.git"` case, as well
as private installations within the github.com domain-space e.g
`"https://my-company.github.com/my-org/my-repo.git"`.

Fixes: #1 