### PR TITLE
Support Service Account in the PipelineRef

### DIFF
--- a/deploy/crds/polling.tekton.dev_repositories_crd.yaml
+++ b/deploy/crds/polling.tekton.dev_repositories_crd.yaml
@@ -143,6 +143,8 @@ spec:
                           type: object
                       type: object
                     type: array
+                  serviceAccountName:
+                    type: string
                 required:
                 - name
                 type: object

--- a/pkg/apis/polling/v1alpha1/repository_types.go
+++ b/pkg/apis/polling/v1alpha1/repository_types.go
@@ -29,10 +29,11 @@ type RepositorySpec struct {
 
 // PipelineRef links to the Pipeline to execute.
 type PipelineRef struct {
-	Name      string                               `json:"name"`
-	Namespace string                               `json:"namespace,omitempty"`
-	Params    []Param                              `json:"params,omitempty"`
-	Resources []pipelinev1.PipelineResourceBinding `json:"resources,omitempty"`
+	Name               string                               `json:"name"`
+	Namespace          string                               `json:"namespace,omitempty"`
+	ServiceAccountName string                               `json:"serviceAccountName,omitempty"`
+	Params             []Param                              `json:"params,omitempty"`
+	Resources          []pipelinev1.PipelineResourceBinding `json:"resources,omitempty"`
 }
 
 type Param struct {

--- a/pkg/controller/repository/repository_controller.go
+++ b/pkg/controller/repository/repository_controller.go
@@ -137,13 +137,14 @@ func (r *ReconcileRepository) Reconcile(req reconcile.Request) (reconcile.Result
 	if runNS == "" {
 		runNS = req.Namespace
 	}
+	serviceAccountName := repo.Spec.Pipeline.ServiceAccountName
 
 	params, err := makeParams(commit, repo.Spec)
 	if err != nil {
 		reqLogger.Error(err, "failed to parse the parameters")
 		return reconcile.Result{}, err
 	}
-	pr, err := r.pipelineRunner.Run(ctx, repo.Spec.Pipeline.Name, runNS, params, repo.Spec.Pipeline.Resources)
+	pr, err := r.pipelineRunner.Run(ctx, repo.Spec.Pipeline.Name, runNS, serviceAccountName, params, repo.Spec.Pipeline.Resources)
 	if err != nil {
 		reqLogger.Error(err, "failed to create a PipelineRun", "pipelineName", repo.Spec.Pipeline.Name)
 		return reconcile.Result{}, err

--- a/pkg/controller/repository/repository_controller_test.go
+++ b/pkg/controller/repository/repository_controller_test.go
@@ -36,6 +36,7 @@ const (
 	testCommitSHA           = "24317a55785cd98d6c9bf50a5204bc6be17e7316"
 	testCommitETag          = `W/"878f43039ad0553d0d3122d8bc171b01"`
 	testPipelineName        = "test-pipeline"
+	testServiceAccountName  = "test-sa"
 )
 
 var (
@@ -65,6 +66,7 @@ func TestReconcileRepositoryWithEmptyPollState(t *testing.T) {
 	fatalIfError(t, err)
 	r.pipelineRunner.(*pipelines.MockRunner).AssertPipelineRun(
 		testPipelineName, testRepositoryNamespace,
+		testServiceAccountName,
 		makeTestParams(map[string]string{"one": testRepoURL, "two": "main"}),
 		testResources)
 
@@ -104,6 +106,7 @@ func TestReconcileRepositoryInPipelineNamespace(t *testing.T) {
 	fatalIfError(t, err)
 	r.pipelineRunner.(*pipelines.MockRunner).AssertPipelineRun(
 		testPipelineName, pipelineNS,
+		testServiceAccountName,
 		makeTestParams(map[string]string{"one": testRepoURL, "two": "main"}),
 		testResources)
 
@@ -300,7 +303,8 @@ func makeRepository(opts ...func(*pollingv1.Repository)) *pollingv1.Repository {
 			Type:      pollingv1.GitHub,
 			Frequency: &metav1.Duration{Duration: testFrequency},
 			Pipeline: pollingv1.PipelineRef{
-				Name: testPipelineName,
+				Name:               testPipelineName,
+				ServiceAccountName: testServiceAccountName,
 				Params: []pollingv1.Param{
 					{Name: "one", Expression: "repoURL"},
 					{Name: "two", Expression: "commit.id"},

--- a/pkg/pipelines/interface.go
+++ b/pkg/pipelines/interface.go
@@ -9,5 +9,5 @@ import (
 // PipelineRunner executes a pipeline by name, creating a PipelineRun with the
 // correct params and resource bindings.
 type PipelineRunner interface {
-	Run(ctx context.Context, pipelineName, ns string, params []pipelinev1.Param, res []pipelinev1.PipelineResourceBinding) (*pipelinev1.PipelineRun, error)
+	Run(ctx context.Context, pipelineName, ns, serviceAccountName string, params []pipelinev1.Param, res []pipelinev1.PipelineResourceBinding) (*pipelinev1.PipelineRun, error)
 }

--- a/pkg/pipelines/pipelines.go
+++ b/pkg/pipelines/pipelines.go
@@ -32,8 +32,8 @@ type ClientPipelineRunner struct {
 
 // Run is an implementation of the PipelineRunner interface.
 // TODO: This should replaced by TriggerTemplates/TriggerBindings.
-func (c *ClientPipelineRunner) Run(ctx context.Context, pipelineName, ns string, params []pipelinev1.Param, res []pipelinev1.PipelineResourceBinding) (*pipelinev1.PipelineRun, error) {
-	pr := c.makePipelineRun(pipelineName, ns, params, res)
+func (c *ClientPipelineRunner) Run(ctx context.Context, pipelineName, ns, serviceAccountName string, params []pipelinev1.Param, res []pipelinev1.PipelineResourceBinding) (*pipelinev1.PipelineRun, error) {
+	pr := c.makePipelineRun(pipelineName, serviceAccountName, ns, params, res)
 	err := c.client.Create(ctx, pr)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create a pipeline run for pipeline %s: %w", pipelineName, err)
@@ -41,14 +41,15 @@ func (c *ClientPipelineRunner) Run(ctx context.Context, pipelineName, ns string,
 	return pr, nil
 }
 
-func (c *ClientPipelineRunner) makePipelineRun(pipelineName, ns string, params []pipelinev1.Param, res []pipelinev1.PipelineResourceBinding) *pipelinev1.PipelineRun {
+func (c *ClientPipelineRunner) makePipelineRun(pipelineName, serviceAccountName, ns string, params []pipelinev1.Param, res []pipelinev1.PipelineResourceBinding) *pipelinev1.PipelineRun {
 	return &pipelinev1.PipelineRun{
 		TypeMeta:   pipelineRunMeta,
 		ObjectMeta: c.objectMeta(ns),
 		Spec: pipelinev1.PipelineRunSpec{
-			PipelineRef: &pipelinev1.PipelineRef{Name: pipelineName},
-			Params:      params,
-			Resources:   applyReplacements(res, params),
+			PipelineRef:        &pipelinev1.PipelineRef{Name: pipelineName},
+			ServiceAccountName: serviceAccountName,
+			Params:             params,
+			Resources:          applyReplacements(res, params),
 		},
 	}
 }

--- a/pkg/pipelines/pipelines_test.go
+++ b/pkg/pipelines/pipelines_test.go
@@ -15,11 +15,12 @@ import (
 )
 
 const (
-	testPipelineName = "test-pipeline"
-	testPipelineRun  = "test-pipeline-run"
-	testRepoURL      = "https://github.com/example/example.git"
-	testSHA          = "35576600886452a3f0f2e9d459924865f4007614"
-	testNamespace    = "test-namespace"
+	testPipelineName       = "test-pipeline"
+	testPipelineRun        = "test-pipeline-run"
+	testRepoURL            = "https://github.com/example/example.git"
+	testSHA                = "35576600886452a3f0f2e9d459924865f4007614"
+	testNamespace          = "test-namespace"
+	testServiceAccountName = "test-sa"
 )
 
 var _ PipelineRunner = (*ClientPipelineRunner)(nil)
@@ -52,7 +53,7 @@ func TestRunPipelineCreatesPipelineRun(t *testing.T) {
 			},
 		},
 	}
-	_, err := r.Run(context.Background(), testPipelineName, testNamespace, params, resources)
+	_, err := r.Run(context.Background(), testPipelineName, testNamespace, testServiceAccountName, params, resources)
 
 	pr := &pipelinev1.PipelineRun{}
 	err = cl.Get(context.Background(), types.NamespacedName{
@@ -70,8 +71,9 @@ func TestRunPipelineCreatesPipelineRun(t *testing.T) {
 			ResourceVersion: "1",
 		},
 		Spec: pipelinev1.PipelineRunSpec{
-			Params:      params,
-			PipelineRef: &pipelinev1.PipelineRef{Name: testPipelineName},
+			Params:             params,
+			PipelineRef:        &pipelinev1.PipelineRef{Name: testPipelineName},
+			ServiceAccountName: testServiceAccountName,
 			Resources: []pipelinev1.PipelineResourceBinding{
 				{
 					Name: "testing",


### PR DESCRIPTION
Problem:
A pipeline run requires a specific service account to access some services, like Quay.io.
The current Repository CRD does not allow to do so.

This PR implements a way to specify a service account's name for the `pipelineRef` in `Repository`.

Here's an example of using serviceAccountName in a Repository:
```
apiVersion: polling.tekton.dev/v1alpha1
kind: Repository
metadata:
  name: polling-repository
spec:
  url: https://github.com/chanwit/podinfo.git
  ref: master
  type: github
  frequency: 30s
  auth:
    secretRef:
      name: github-token
    key: token
  pipelineRef:
    name: build-podinfo-pipeline
    serviceAccountName: demo-service-account
    params:
    - name: imageTag
      expression: commit.sha
    resources:
    - name: app-git
      resourceSpec:
        type: git
        params:
        - name: revision
          value: $(params.imageTag)
        - name: url
          value: git@github.com:chanwit/podinfo.git # access via ssh
    - name: app-image
      resourceSpec:
        type: image
        params:
          - name: url
            value: quay.io/chanwit/podinfo
```