### PR TITLE
Support workspaces in Repository

### DIFF
--- a/deploy/crds/polling.tekton.dev_repositories_crd.yaml
+++ b/deploy/crds/polling.tekton.dev_repositories_crd.yaml
@@ -145,6 +145,415 @@ spec:
                     type: array
                   serviceAccountName:
                     type: string
+                  workspaces:
+                    items:
+                      description: WorkspaceBinding maps a Task's declared workspace
+                        to a Volume.
+                      properties:
+                        configMap:
+                          description: ConfigMap represents a configMap that should
+                            populate this workspace.
+                          properties:
+                            defaultMode:
+                              description: 'Optional: mode bits to use on created
+                                files by default. Must be a value between 0 and 0777.
+                                Defaults to 0644. Directories within the path are
+                                not affected by this setting. This might be in conflict
+                                with other options that affect the file mode, like
+                                fsGroup, and the result can be other mode bits set.'
+                              format: int32
+                              type: integer
+                            items:
+                              description: If unspecified, each key-value pair in
+                                the Data field of the referenced ConfigMap will be
+                                projected into the volume as a file whose name is
+                                the key and content is the value. If specified, the
+                                listed keys will be projected into the specified paths,
+                                and unlisted keys will not be present. If a key is
+                                specified which is not present in the ConfigMap, the
+                                volume setup will error unless it is marked optional.
+                                Paths must be relative and may not contain the '..'
+                                path or start with '..'.
+                              items:
+                                description: Maps a string key to a path within a
+                                  volume.
+                                properties:
+                                  key:
+                                    description: The key to project.
+                                    type: string
+                                  mode:
+                                    description: 'Optional: mode bits to use on this
+                                      file, must be a value between 0 and 0777. If
+                                      not specified, the volume defaultMode will be
+                                      used. This might be in conflict with other options
+                                      that affect the file mode, like fsGroup, and
+                                      the result can be other mode bits set.'
+                                    format: int32
+                                    type: integer
+                                  path:
+                                    description: The relative path of the file to
+                                      map the key to. May not be an absolute path.
+                                      May not contain the path element '..'. May not
+                                      start with the string '..'.
+                                    type: string
+                                required:
+                                - key
+                                - path
+                                type: object
+                              type: array
+                            name:
+                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                TODO: Add other useful fields. apiVersion, kind, uid?'
+                              type: string
+                            optional:
+                              description: Specify whether the ConfigMap or its keys
+                                must be defined
+                              type: boolean
+                          type: object
+                        emptyDir:
+                          description: 'EmptyDir represents a temporary directory
+                            that shares a Task''s lifetime. More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir
+                            Either this OR PersistentVolumeClaim can be used.'
+                          properties:
+                            medium:
+                              description: 'What type of storage medium should back
+                                this directory. The default is "" which means to use
+                                the node''s default medium. Must be an empty string
+                                (default) or Memory. More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir'
+                              type: string
+                            sizeLimit:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              description: 'Total amount of local storage required
+                                for this EmptyDir volume. The size limit is also applicable
+                                for memory medium. The maximum usage on memory medium
+                                EmptyDir would be the minimum value between the SizeLimit
+                                specified here and the sum of memory limits of all
+                                containers in a pod. The default is nil which means
+                                that the limit is undefined. More info: http://kubernetes.io/docs/user-guide/volumes#emptydir'
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
+                          type: object
+                        name:
+                          description: Name is the name of the workspace populated
+                            by the volume.
+                          type: string
+                        persistentVolumeClaim:
+                          description: PersistentVolumeClaimVolumeSource represents
+                            a reference to a PersistentVolumeClaim in the same namespace.
+                            Either this OR EmptyDir can be used.
+                          properties:
+                            claimName:
+                              description: 'ClaimName is the name of a PersistentVolumeClaim
+                                in the same namespace as the pod using this volume.
+                                More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
+                              type: string
+                            readOnly:
+                              description: Will force the ReadOnly setting in VolumeMounts.
+                                Default false.
+                              type: boolean
+                          required:
+                          - claimName
+                          type: object
+                        secret:
+                          description: Secret represents a secret that should populate
+                            this workspace.
+                          properties:
+                            defaultMode:
+                              description: 'Optional: mode bits to use on created
+                                files by default. Must be a value between 0 and 0777.
+                                Defaults to 0644. Directories within the path are
+                                not affected by this setting. This might be in conflict
+                                with other options that affect the file mode, like
+                                fsGroup, and the result can be other mode bits set.'
+                              format: int32
+                              type: integer
+                            items:
+                              description: If unspecified, each key-value pair in
+                                the Data field of the referenced Secret will be projected
+                                into the volume as a file whose name is the key and
+                                content is the value. If specified, the listed keys
+                                will be projected into the specified paths, and unlisted
+                                keys will not be present. If a key is specified which
+                                is not present in the Secret, the volume setup will
+                                error unless it is marked optional. Paths must be
+                                relative and may not contain the '..' path or start
+                                with '..'.
+                              items:
+                                description: Maps a string key to a path within a
+                                  volume.
+                                properties:
+                                  key:
+                                    description: The key to project.
+                                    type: string
+                                  mode:
+                                    description: 'Optional: mode bits to use on this
+                                      file, must be a value between 0 and 0777. If
+                                      not specified, the volume defaultMode will be
+                                      used. This might be in conflict with other options
+                                      that affect the file mode, like fsGroup, and
+                                      the result can be other mode bits set.'
+                                    format: int32
+                                    type: integer
+                                  path:
+                                    description: The relative path of the file to
+                                      map the key to. May not be an absolute path.
+                                      May not contain the path element '..'. May not
+                                      start with the string '..'.
+                                    type: string
+                                required:
+                                - key
+                                - path
+                                type: object
+                              type: array
+                            optional:
+                              description: Specify whether the Secret or its keys
+                                must be defined
+                              type: boolean
+                            secretName:
+                              description: 'Name of the secret in the pod''s namespace
+                                to use. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret'
+                              type: string
+                          type: object
+                        subPath:
+                          description: SubPath is optionally a directory on the volume
+                            which should be used for this binding (i.e. the volume
+                            will be mounted at this sub directory).
+                          type: string
+                        volumeClaimTemplate:
+                          description: VolumeClaimTemplate is a template for a claim
+                            that will be created in the same namespace. The PipelineRun
+                            controller is responsible for creating a unique claim
+                            for each instance of PipelineRun.
+                          properties:
+                            apiVersion:
+                              description: 'APIVersion defines the versioned schema
+                                of this representation of an object. Servers should
+                                convert recognized schemas to the latest internal
+                                value, and may reject unrecognized values. More info:
+                                https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+                              type: string
+                            kind:
+                              description: 'Kind is a string value representing the
+                                REST resource this object represents. Servers may
+                                infer this from the endpoint the client submits requests
+                                to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                              type: string
+                            metadata:
+                              description: 'Standard object''s metadata. More info:
+                                https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata'
+                              type: object
+                            spec:
+                              description: 'Spec defines the desired characteristics
+                                of a volume requested by a pod author. More info:
+                                https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
+                              properties:
+                                accessModes:
+                                  description: 'AccessModes contains the desired access
+                                    modes the volume should have. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1'
+                                  items:
+                                    type: string
+                                  type: array
+                                dataSource:
+                                  description: This field requires the VolumeSnapshotDataSource
+                                    alpha feature gate to be enabled and currently
+                                    VolumeSnapshot is the only supported data source.
+                                    If the provisioner can support VolumeSnapshot
+                                    data source, it will create a new volume and data
+                                    will be restored to the volume at the same time.
+                                    If the provisioner does not support VolumeSnapshot
+                                    data source, volume will not be created and the
+                                    failure will be reported as an event. In the future,
+                                    we plan to support more data source types and
+                                    the behavior of the provisioner may change.
+                                  properties:
+                                    apiGroup:
+                                      description: APIGroup is the group for the resource
+                                        being referenced. If APIGroup is not specified,
+                                        the specified Kind must be in the core API
+                                        group. For any other third-party types, APIGroup
+                                        is required.
+                                      type: string
+                                    kind:
+                                      description: Kind is the type of resource being
+                                        referenced
+                                      type: string
+                                    name:
+                                      description: Name is the name of resource being
+                                        referenced
+                                      type: string
+                                  required:
+                                  - kind
+                                  - name
+                                  type: object
+                                resources:
+                                  description: 'Resources represents the minimum resources
+                                    the volume should have. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources'
+                                  properties:
+                                    limits:
+                                      additionalProperties:
+                                        anyOf:
+                                        - type: integer
+                                        - type: string
+                                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                        x-kubernetes-int-or-string: true
+                                      description: 'Limits describes the maximum amount
+                                        of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                                      type: object
+                                    requests:
+                                      additionalProperties:
+                                        anyOf:
+                                        - type: integer
+                                        - type: string
+                                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                        x-kubernetes-int-or-string: true
+                                      description: 'Requests describes the minimum
+                                        amount of compute resources required. If Requests
+                                        is omitted for a container, it defaults to
+                                        Limits if that is explicitly specified, otherwise
+                                        to an implementation-defined value. More info:
+                                        https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                                      type: object
+                                  type: object
+                                selector:
+                                  description: A label query over volumes to consider
+                                    for binding.
+                                  properties:
+                                    matchExpressions:
+                                      description: matchExpressions is a list of label
+                                        selector requirements. The requirements are
+                                        ANDed.
+                                      items:
+                                        description: A label selector requirement
+                                          is a selector that contains values, a key,
+                                          and an operator that relates the key and
+                                          values.
+                                        properties:
+                                          key:
+                                            description: key is the label key that
+                                              the selector applies to.
+                                            type: string
+                                          operator:
+                                            description: operator represents a key's
+                                              relationship to a set of values. Valid
+                                              operators are In, NotIn, Exists and
+                                              DoesNotExist.
+                                            type: string
+                                          values:
+                                            description: values is an array of string
+                                              values. If the operator is In or NotIn,
+                                              the values array must be non-empty.
+                                              If the operator is Exists or DoesNotExist,
+                                              the values array must be empty. This
+                                              array is replaced during a strategic
+                                              merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                    matchLabels:
+                                      additionalProperties:
+                                        type: string
+                                      description: matchLabels is a map of {key,value}
+                                        pairs. A single {key,value} in the matchLabels
+                                        map is equivalent to an element of matchExpressions,
+                                        whose key field is "key", the operator is
+                                        "In", and the values array contains only "value".
+                                        The requirements are ANDed.
+                                      type: object
+                                  type: object
+                                storageClassName:
+                                  description: 'Name of the StorageClass required
+                                    by the claim. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1'
+                                  type: string
+                                volumeMode:
+                                  description: volumeMode defines what type of volume
+                                    is required by the claim. Value of Filesystem
+                                    is implied when not included in claim spec. This
+                                    is a beta feature.
+                                  type: string
+                                volumeName:
+                                  description: VolumeName is the binding reference
+                                    to the PersistentVolume backing this claim.
+                                  type: string
+                              type: object
+                            status:
+                              description: 'Status represents the current information/status
+                                of a persistent volume claim. Read-only. More info:
+                                https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
+                              properties:
+                                accessModes:
+                                  description: 'AccessModes contains the actual access
+                                    modes the volume backing the PVC has. More info:
+                                    https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1'
+                                  items:
+                                    type: string
+                                  type: array
+                                capacity:
+                                  additionalProperties:
+                                    anyOf:
+                                    - type: integer
+                                    - type: string
+                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                    x-kubernetes-int-or-string: true
+                                  description: Represents the actual resources of
+                                    the underlying volume.
+                                  type: object
+                                conditions:
+                                  description: Current Condition of persistent volume
+                                    claim. If underlying persistent volume is being
+                                    resized then the Condition will be set to 'ResizeStarted'.
+                                  items:
+                                    description: PersistentVolumeClaimCondition contails
+                                      details about state of pvc
+                                    properties:
+                                      lastProbeTime:
+                                        description: Last time we probed the condition.
+                                        format: date-time
+                                        type: string
+                                      lastTransitionTime:
+                                        description: Last time the condition transitioned
+                                          from one status to another.
+                                        format: date-time
+                                        type: string
+                                      message:
+                                        description: Human-readable message indicating
+                                          details about last transition.
+                                        type: string
+                                      reason:
+                                        description: Unique, this should be a short,
+                                          machine understandable string that gives
+                                          the reason for condition's last transition.
+                                          If it reports "ResizeStarted" that means
+                                          the underlying persistent volume is being
+                                          resized.
+                                        type: string
+                                      status:
+                                        type: string
+                                      type:
+                                        description: PersistentVolumeClaimConditionType
+                                          is a valid value of PersistentVolumeClaimCondition.Type
+                                        type: string
+                                    required:
+                                    - status
+                                    - type
+                                    type: object
+                                  type: array
+                                phase:
+                                  description: Phase represents the current phase
+                                    of PersistentVolumeClaim.
+                                  type: string
+                              type: object
+                          type: object
+                      required:
+                      - name
+                      type: object
+                    type: array
                 required:
                 - name
                 type: object

--- a/pkg/apis/polling/v1alpha1/repository_types.go
+++ b/pkg/apis/polling/v1alpha1/repository_types.go
@@ -34,6 +34,7 @@ type PipelineRef struct {
 	ServiceAccountName string                               `json:"serviceAccountName,omitempty"`
 	Params             []Param                              `json:"params,omitempty"`
 	Resources          []pipelinev1.PipelineResourceBinding `json:"resources,omitempty"`
+	Workspaces         []pipelinev1.WorkspaceBinding        `json:"workspaces,omitempty"`
 }
 
 type Param struct {

--- a/pkg/apis/polling/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/polling/v1alpha1/zz_generated.deepcopy.go
@@ -58,6 +58,13 @@ func (in *PipelineRef) DeepCopyInto(out *PipelineRef) {
 			(*in)[i].DeepCopyInto(&(*out)[i])
 		}
 	}
+	if in.Workspaces != nil {
+		in, out := &in.Workspaces, &out.Workspaces
+		*out = make([]v1beta1.WorkspaceBinding, len(*in))
+		for i := range *in {
+			(*in)[i].DeepCopyInto(&(*out)[i])
+		}
+	}
 	return
 }
 

--- a/pkg/controller/repository/repository_controller.go
+++ b/pkg/controller/repository/repository_controller.go
@@ -138,13 +138,14 @@ func (r *ReconcileRepository) Reconcile(req reconcile.Request) (reconcile.Result
 		runNS = req.Namespace
 	}
 	serviceAccountName := repo.Spec.Pipeline.ServiceAccountName
+	workspaces := repo.Spec.Pipeline.Workspaces
 
 	params, err := makeParams(commit, repo.Spec)
 	if err != nil {
 		reqLogger.Error(err, "failed to parse the parameters")
 		return reconcile.Result{}, err
 	}
-	pr, err := r.pipelineRunner.Run(ctx, repo.Spec.Pipeline.Name, runNS, serviceAccountName, params, repo.Spec.Pipeline.Resources)
+	pr, err := r.pipelineRunner.Run(ctx, repo.Spec.Pipeline.Name, runNS, serviceAccountName, params, repo.Spec.Pipeline.Resources, workspaces)
 	if err != nil {
 		reqLogger.Error(err, "failed to create a PipelineRun", "pipelineName", repo.Spec.Pipeline.Name)
 		return reconcile.Result{}, err

--- a/pkg/controller/repository/repository_controller_test.go
+++ b/pkg/controller/repository/repository_controller_test.go
@@ -42,7 +42,7 @@ const (
 var (
 	_ reconcile.Reconciler = &ReconcileRepository{}
 
-	testResources  = []pipelinev1beta1.PipelineResourceBinding{{Name: "testing"}}
+	testResources = []pipelinev1beta1.PipelineResourceBinding{{Name: "testing"}}
 	testWorkspaces = []pipelinev1beta1.WorkspaceBinding{
 		{
 			Name:                  "test-workspace",

--- a/pkg/controller/repository/repository_controller_test.go
+++ b/pkg/controller/repository/repository_controller_test.go
@@ -42,7 +42,13 @@ const (
 var (
 	_ reconcile.Reconciler = &ReconcileRepository{}
 
-	testResources = []pipelinev1beta1.PipelineResourceBinding{{Name: "testing"}}
+	testResources  = []pipelinev1beta1.PipelineResourceBinding{{Name: "testing"}}
+	testWorkspaces = []pipelinev1beta1.WorkspaceBinding{
+		{
+			Name:                  "test-workspace",
+			PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{ClaimName: "test-pvc"},
+		},
+	}
 )
 
 func TestReconcileRepositoryWithEmptyPollState(t *testing.T) {
@@ -68,7 +74,7 @@ func TestReconcileRepositoryWithEmptyPollState(t *testing.T) {
 		testPipelineName, testRepositoryNamespace,
 		testServiceAccountName,
 		makeTestParams(map[string]string{"one": testRepoURL, "two": "main"}),
-		testResources)
+		testResources, testWorkspaces)
 
 	wantStatus := pollingv1.RepositoryStatus{
 		PollStatus: pollingv1.PollStatus{
@@ -108,7 +114,7 @@ func TestReconcileRepositoryInPipelineNamespace(t *testing.T) {
 		testPipelineName, pipelineNS,
 		testServiceAccountName,
 		makeTestParams(map[string]string{"one": testRepoURL, "two": "main"}),
-		testResources)
+		testResources, testWorkspaces)
 
 	wantStatus := pollingv1.RepositoryStatus{
 		PollStatus: pollingv1.PollStatus{
@@ -309,7 +315,8 @@ func makeRepository(opts ...func(*pollingv1.Repository)) *pollingv1.Repository {
 					{Name: "one", Expression: "repoURL"},
 					{Name: "two", Expression: "commit.id"},
 				},
-				Resources: testResources,
+				Resources:  testResources,
+				Workspaces: testWorkspaces,
 			},
 		},
 		Status: pollingv1.RepositoryStatus{},

--- a/pkg/pipelines/interface.go
+++ b/pkg/pipelines/interface.go
@@ -9,5 +9,5 @@ import (
 // PipelineRunner executes a pipeline by name, creating a PipelineRun with the
 // correct params and resource bindings.
 type PipelineRunner interface {
-	Run(ctx context.Context, pipelineName, ns, serviceAccountName string, params []pipelinev1.Param, res []pipelinev1.PipelineResourceBinding) (*pipelinev1.PipelineRun, error)
+	Run(ctx context.Context, pipelineName, ns, serviceAccountName string, params []pipelinev1.Param, res []pipelinev1.PipelineResourceBinding, ws []pipelinev1.WorkspaceBinding) (*pipelinev1.PipelineRun, error)
 }

--- a/pkg/pipelines/mock.go
+++ b/pkg/pipelines/mock.go
@@ -27,19 +27,20 @@ type run struct {
 	serviceAccountName string
 	params             []pipelinev1.Param
 	resources          []pipelinev1.PipelineResourceBinding
+	workspaces         []pipelinev1.WorkspaceBinding
 }
 
 // Run is an implementation of the PipelineRunner interface.
-func (m *MockRunner) Run(ctx context.Context, pipelineName, ns, serviceAccountName string, params []pipelinev1.Param, res []pipelinev1.PipelineResourceBinding) (*pipelinev1.PipelineRun, error) {
+func (m *MockRunner) Run(ctx context.Context, pipelineName, ns, serviceAccountName string, params []pipelinev1.Param, res []pipelinev1.PipelineResourceBinding, ws []pipelinev1.WorkspaceBinding) (*pipelinev1.PipelineRun, error) {
 	if m.runError != nil {
 		return nil, m.runError
 	}
-	m.runs[mockKey(ns, pipelineName)] = run{serviceAccountName: serviceAccountName, params: params, resources: res}
+	m.runs[mockKey(ns, pipelineName)] = run{serviceAccountName: serviceAccountName, params: params, resources: res, workspaces: ws}
 	return &pipelinev1.PipelineRun{}, nil
 }
 
 // AssertPipelineRun ensures that the pipeline run was triggered.
-func (m *MockRunner) AssertPipelineRun(pipelineName, ns string, serviceAccountName string, wantParams []pipelinev1.Param, wantResources []pipelinev1.PipelineResourceBinding) {
+func (m *MockRunner) AssertPipelineRun(pipelineName, ns string, serviceAccountName string, wantParams []pipelinev1.Param, wantResources []pipelinev1.PipelineResourceBinding, wantWorkspaces []pipelinev1.WorkspaceBinding) {
 	m.t.Helper()
 	run, ok := m.runs[mockKey(ns, pipelineName)]
 	if !ok {
@@ -55,6 +56,10 @@ func (m *MockRunner) AssertPipelineRun(pipelineName, ns string, serviceAccountNa
 
 	if diff := cmp.Diff(serviceAccountName, run.serviceAccountName); diff != "" {
 		m.t.Fatalf("incorrect serviceAccountName for pipeline run:\n%s", diff)
+	}
+
+	if diff := cmp.Diff(wantWorkspaces, run.workspaces); diff != "" {
+		m.t.Fatalf("incorrect workspaces for pipeline run:\n%s", diff)
 	}
 }
 

--- a/pkg/pipelines/pipelines.go
+++ b/pkg/pipelines/pipelines.go
@@ -32,8 +32,8 @@ type ClientPipelineRunner struct {
 
 // Run is an implementation of the PipelineRunner interface.
 // TODO: This should replaced by TriggerTemplates/TriggerBindings.
-func (c *ClientPipelineRunner) Run(ctx context.Context, pipelineName, ns, serviceAccountName string, params []pipelinev1.Param, res []pipelinev1.PipelineResourceBinding) (*pipelinev1.PipelineRun, error) {
-	pr := c.makePipelineRun(pipelineName, serviceAccountName, ns, params, res)
+func (c *ClientPipelineRunner) Run(ctx context.Context, pipelineName, ns, serviceAccountName string, params []pipelinev1.Param, res []pipelinev1.PipelineResourceBinding, ws []pipelinev1.WorkspaceBinding) (*pipelinev1.PipelineRun, error) {
+	pr := c.makePipelineRun(pipelineName, serviceAccountName, ns, params, res, ws)
 	err := c.client.Create(ctx, pr)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create a pipeline run for pipeline %s: %w", pipelineName, err)
@@ -41,7 +41,7 @@ func (c *ClientPipelineRunner) Run(ctx context.Context, pipelineName, ns, servic
 	return pr, nil
 }
 
-func (c *ClientPipelineRunner) makePipelineRun(pipelineName, serviceAccountName, ns string, params []pipelinev1.Param, res []pipelinev1.PipelineResourceBinding) *pipelinev1.PipelineRun {
+func (c *ClientPipelineRunner) makePipelineRun(pipelineName, serviceAccountName, ns string, params []pipelinev1.Param, res []pipelinev1.PipelineResourceBinding, ws []pipelinev1.WorkspaceBinding) *pipelinev1.PipelineRun {
 	return &pipelinev1.PipelineRun{
 		TypeMeta:   pipelineRunMeta,
 		ObjectMeta: c.objectMeta(ns),
@@ -50,6 +50,7 @@ func (c *ClientPipelineRunner) makePipelineRun(pipelineName, serviceAccountName,
 			ServiceAccountName: serviceAccountName,
 			Params:             params,
 			Resources:          applyReplacements(res, params),
+			Workspaces:         ws,
 		},
 	}
 }

--- a/pkg/pipelines/pipelines_test.go
+++ b/pkg/pipelines/pipelines_test.go
@@ -6,6 +6,8 @@ import (
 
 	pipelinev1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
 	resourcev1alpha1 "github.com/tektoncd/pipeline/pkg/apis/resource/v1alpha1"
+	corev1 "k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes/scheme"
@@ -53,7 +55,13 @@ func TestRunPipelineCreatesPipelineRun(t *testing.T) {
 			},
 		},
 	}
-	_, err := r.Run(context.Background(), testPipelineName, testNamespace, testServiceAccountName, params, resources)
+	workspaces := []pipelinev1.WorkspaceBinding{
+		{
+			Name:                  "test-workspace",
+			PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{ClaimName: "test-pvc"},
+		},
+	}
+	_, err := r.Run(context.Background(), testPipelineName, testNamespace, testServiceAccountName, params, resources, workspaces)
 
 	pr := &pipelinev1.PipelineRun{}
 	err = cl.Get(context.Background(), types.NamespacedName{
@@ -85,6 +93,12 @@ func TestRunPipelineCreatesPipelineRun(t *testing.T) {
 							},
 						},
 					},
+				},
+			},
+			Workspaces: []pipelinev1.WorkspaceBinding{
+				{
+					Name:                  "test-workspace",
+					PersistentVolumeClaim: &v1.PersistentVolumeClaimVolumeSource{ClaimName: "test-pvc"},
 				},
 			},
 		},


### PR DESCRIPTION
Hi there!

To use workspaces with PipelineRun, Repository CRD requires to support workspaces.

This PR implements a way to use workspaces in Repository CRD.

The following example uses workspaces.

```
apiVersion: polling.tekton.dev/v1alpha1
kind: Repository
metadata:
  name: demo-app-repository
  namespace: tekton-polling-operator
spec:
  url: https://github.com/bigkevmcd/tekton-polling-operator.git
  ref: main
  frequency: 5m
  type: github
  pipelineRef:
    name: ci-pipeline
    namespace: tekton-pipelines
    params:
    - name: gitRevision
      expression: commit.sha
    - name: repoURL
      expression: repoURL
    workspaces:
      - name: git-source
        persistentVolumeClaim:
          claimName: tekton-volume
```