### PR TITLE
clarify auth description

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ spec:
 
 This will fetch the secret, and get the value in `token` and use that to authenticate the API call to GitHub. The secret may contain multiple values and you can configure which key within the `Secret` by setting the `key` field in the `spec.auth` configuration, this defaults to `token`.
 ```yaml
-piVersion: v1
+apiVersion: v1
 kind: Secret
 metadata:
   name: github-user-pass

--- a/README.md
+++ b/README.md
@@ -140,7 +140,7 @@ metadata:
     tekton.dev/git-0: https://github.com/
 type: kubernetes.io/basic-auth
 stringData:
-    username: "shohagrana64"
+    username: "githubUsername"
     password: "githubAccessToken(PAT)"
 ```
 In such a case, the auth part will be:

--- a/README.md
+++ b/README.md
@@ -130,9 +130,26 @@ spec:
     key: token
 ```
 
-This will fetch the secret, and get the value in `token` and use that to
-authenticate the API call to GitHub.
-
+This will fetch the secret, and get the value in `token` and use that to authenticate the API call to GitHub. The secret may contain multiple values. For example: 
+```yaml
+piVersion: v1
+kind: Secret
+metadata:
+  name: github-user-pass
+  annotations:
+    tekton.dev/git-0: https://github.com/
+type: kubernetes.io/basic-auth
+stringData:
+    username: "shohagrana64"
+    password: "githubAccessToken(PAT)"
+```
+In such a case, the auth part will be:
+```yaml
+  auth:
+    secretRef:
+      name:  github-user-pass
+    key: password
+```
 ## Creating PipelineRuns in other namespaces
 
 See the documentation [here](docs/configuring_security.md) for how to grant

--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ spec:
     key: token
 ```
 
-This will fetch the secret, and get the value in `token` and use that to authenticate the API call to GitHub. The secret may contain multiple values. For example: 
+This will fetch the secret, and get the value in `token` and use that to authenticate the API call to GitHub. The secret may contain multiple values and you can configure which key within the `Secret` by setting the `key` field in the `spec.auth` configuration, this defaults to `token`.
 ```yaml
 piVersion: v1
 kind: Secret


### PR DESCRIPTION
The auth description is a little confusing. This will help clarify how to use private repos.